### PR TITLE
refactor: use graphql visitor

### DIFF
--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -11,14 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {
-  BaseVisitor,
-  ParsedConfig,
-  RawConfig,
-} from "@graphql-codegen/visitor-plugin-common";
+import { BaseVisitor, RawConfig } from "@graphql-codegen/visitor-plugin-common";
 import {
   EnumTypeDefinitionNode,
-  EnumValueDefinitionNode,
   GraphQLSchema,
   InterfaceTypeDefinitionNode,
   InputObjectTypeDefinitionNode,
@@ -26,28 +21,21 @@ import {
   UnionTypeDefinitionNode,
 } from "graphql";
 import { GraphQLKotlinCodegenConfig } from "./plugin";
-import {
-  buildEnumTypeDefinition,
-  buildEnumValueDefinition,
-} from "./definitions/enum";
+import { buildEnumTypeDefinition } from "./definitions/enum";
 import { buildInterfaceDefinition } from "./definitions/interface";
 import { buildInputObjectDefinition } from "./definitions/input";
 import { buildObjectTypeDefinition } from "./definitions/object";
 import { buildUnionTypeDefinition } from "./definitions/union";
 
-export class KotlinResolversVisitor extends BaseVisitor<
+export class KotlinVisitor extends BaseVisitor<
   RawConfig,
-  GraphQLKotlinCodegenConfig & ParsedConfig
+  GraphQLKotlinCodegenConfig
 > {
   constructor(
     rawConfig: GraphQLKotlinCodegenConfig,
     protected _schema: GraphQLSchema,
   ) {
-    super(rawConfig, rawConfig as GraphQLKotlinCodegenConfig & ParsedConfig);
-  }
-
-  EnumValueDefinition(node: EnumValueDefinitionNode): string {
-    return buildEnumValueDefinition.bind(this)(node);
+    super(rawConfig, rawConfig);
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -49,8 +49,7 @@ const testCases = await Promise.all(
     }
     return {
       testName,
-      config: (await import(`${absolutePath}/codegen.config.ts`))
-        .default as GraphQLKotlinCodegenConfig,
+      config: (await import(`${absolutePath}/codegen.config.ts`)).default,
     };
   }),
 );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Use `visitor` method from `graphql` instead of unsupported `oldVisit` method
