### PR TITLE
fix: annotate fields with out-of-scope unions

### DIFF
--- a/src/helpers/build-annotations.ts
+++ b/src/helpers/build-annotations.ts
@@ -21,7 +21,6 @@ import {
 import { buildDirectiveAnnotations } from "./build-directive-annotations";
 import { CodegenConfig } from "../plugin";
 import { TypeMetadata } from "./build-type-metadata";
-import { dependentTypeIsInScope } from "./dependent-type-is-in-scope";
 
 export type DefinitionNode =
   | TypeDefinitionNode
@@ -56,11 +55,9 @@ export function buildAnnotations({
   const directiveAnnotations = definitionNode
     ? buildDirectiveAnnotations(definitionNode, config, description)
     : "";
-  const unionAnnotation =
-    resolvedType?.baseType &&
-    dependentTypeIsInScope(resolvedType.baseType, config)
-      ? `@${resolvedType.baseType}\n`
-      : "";
+  const unionAnnotation = resolvedType?.annotation
+    ? `@${resolvedType.annotation}\n`
+    : "";
 
   const annotations = [
     unionAnnotation,

--- a/src/helpers/build-type-metadata.ts
+++ b/src/helpers/build-type-metadata.ts
@@ -21,12 +21,11 @@ import {
 } from "graphql";
 import { getBaseTypeNode } from "@graphql-codegen/visitor-plugin-common";
 import { wrapTypeWithModifiers } from "@graphql-codegen/java-common";
-import { dependentTypeIsInScope } from "./dependent-type-is-in-scope";
 import { CodegenConfig } from "../plugin";
 
 export interface TypeMetadata {
   typeName: string;
-  baseType?: string;
+  annotation?: string;
   defaultValue: string;
   isNullable: boolean;
 }
@@ -48,7 +47,6 @@ export function buildTypeMetadata(
     defaultValue,
     isNullable,
   };
-  const defaultTypeName = schemaType.name;
 
   if (isScalarType(schemaType)) {
     const scalars = [...KOTLIN_SCALARS, ...(config.extraScalars ?? [])];
@@ -61,18 +59,15 @@ export function buildTypeMetadata(
       typeName: buildListType(typeNode, scalarTypeName),
     };
   } else if (isUnionType(schemaType)) {
-    const unionTypeName = dependentTypeIsInScope(defaultTypeName, config)
-      ? "Any"
-      : defaultTypeName;
     return {
       ...commonMetadata,
-      baseType: defaultTypeName,
-      typeName: buildListType(typeNode, unionTypeName),
+      annotation: schemaType.name,
+      typeName: buildListType(typeNode, "Any"),
     };
   } else {
     return {
       ...commonMetadata,
-      typeName: buildListType(typeNode, defaultTypeName),
+      typeName: buildListType(typeNode, schemaType.name),
     };
   }
 }

--- a/test/unit/should_honor_dependentTypesInScope_config/expected.kt
+++ b/test/unit/should_honor_dependentTypesInScope_config/expected.kt
@@ -13,7 +13,8 @@ data class TypeInScope(
     val field: String? = null,
     @UnionInScope
     val unionInScopeField: Any? = null,
-    val unionOutOfScopeField: UnionOutOfScope? = null
+    @UnionOutOfScope
+    val unionOutOfScopeField: Any? = null
 )
 
 @GraphQLUnion(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- We should never end up with a generated class where the field type is an annotation class. This actually prevents setting a value of one of the union member types, so such a field should have type `Any` with the documentational annotation class above it.
