### PR TITLE
fix: avoid using @Deprecated on union type

### DIFF
--- a/src/helpers/build-annotations.ts
+++ b/src/helpers/build-annotations.ts
@@ -41,10 +41,13 @@ export function buildAnnotations({
 }) {
   const description =
     inputDescription ?? definitionNode?.description?.value ?? "";
-  const descriptionAnnotator = isDeprecatedDescription(description)
+  const descriptionAnnotator = isDeprecatedDescription(
+    description,
+    resolvedType,
+  )
     ? "@Deprecated"
     : "@GraphQLDescription";
-  const descriptionValue = isDeprecatedDescription(description)
+  const descriptionValue = isDeprecatedDescription(description, resolvedType)
     ? description.replace("DEPRECATED: ", "")
     : description;
   const trimmedDescription = trimDescription(descriptionValue);
@@ -53,7 +56,12 @@ export function buildAnnotations({
     : "";
 
   const directiveAnnotations = definitionNode
-    ? buildDirectiveAnnotations(definitionNode, config, description)
+    ? buildDirectiveAnnotations(
+        definitionNode,
+        config,
+        description,
+        resolvedType,
+      )
     : "";
   const unionAnnotation = resolvedType?.unionAnnotation
     ? `@${resolvedType.unionAnnotation}\n`
@@ -78,8 +86,13 @@ export function buildAnnotations({
   );
 }
 
-export function isDeprecatedDescription(description?: string) {
-  return description?.startsWith("DEPRECATED: ");
+export function isDeprecatedDescription(
+  description?: string,
+  resolvedType?: TypeMetadata,
+) {
+  return (
+    description?.startsWith("DEPRECATED: ") && !resolvedType?.unionAnnotation
+  );
 }
 
 function trimDescription(description: string) {

--- a/test/unit/should_annotate_types_properly/expected.kt
+++ b/test/unit/should_annotate_types_properly/expected.kt
@@ -8,5 +8,26 @@ data class MyType(
     @GraphQLDescription("A description for email")
     val email: String? = null,
     @GraphQLDescription("A `weird` description for name")
-    val name: String? = null
+    val name: String? = null,
+    @Deprecated("Use something else instead")
+    val deprecated1: String? = null,
+    @Deprecated("")
+    val deprecated2: String? = null,
+    @Deprecated("Deprecated directive works too")
+    val deprecated3: String? = null,
+    @Deprecated("It only takes the first one")
+    val deprecated4: String? = null,
+    @MyUnion
+    @GraphQLDescription("DEPRECATED: It uses the GraphQLDescription annotation for union types")
+    val deprecated5: Any? = null,
+    @MyUnion
+    @GraphQLDescription("It uses the GraphQLDescription annotation for union types")
+    val deprecated6: Any? = null
 )
+
+@GraphQLUnion(
+    name = "MyUnion",
+    possibleTypes = [MyType::class],
+    description = ""
+)
+annotation class MyUnion

--- a/test/unit/should_annotate_types_properly/schema.graphql
+++ b/test/unit/should_annotate_types_properly/schema.graphql
@@ -11,4 +11,19 @@ type MyType {
   A \`weird\` description for name
   """
   name: String
+  "DEPRECATED: Use something else instead"
+  deprecated1: String
+  deprecated2: String @deprecated
+  deprecated3: String @deprecated(reason: "Deprecated directive works too")
+  "DEPRECATED: It only takes the first one"
+  deprecated4: String
+    @deprecated(reason: "when you have multiple deprecated annotations")
+  "DEPRECATED: It uses the GraphQLDescription annotation for union types"
+  deprecated5: MyUnion
+  deprecated6: MyUnion
+    @deprecated(
+      reason: "It uses the GraphQLDescription annotation for union types"
+    )
 }
+
+union MyUnion = MyType

--- a/test/unit/should_generate_input_types_properly/expected.kt
+++ b/test/unit/should_generate_input_types_properly/expected.kt
@@ -7,13 +7,5 @@ data class MyInputType(
     val username: String? = null,
     @GraphQLDescription("A description for email")
     val email: String? = null,
-    val name: String? = null,
-    @Deprecated("Use something else instead")
-    val deprecated1: String? = null,
-    @Deprecated("")
-    val deprecated2: String? = null,
-    @Deprecated("Deprecated directive works too")
-    val deprecated3: String? = null,
-    @Deprecated("It only takes the first one")
-    val deprecated4: String? = null
+    val name: String? = null
 )

--- a/test/unit/should_generate_input_types_properly/schema.graphql
+++ b/test/unit/should_generate_input_types_properly/schema.graphql
@@ -4,11 +4,4 @@ input MyInputType {
   "A description for email"
   email: String
   name: String
-  "DEPRECATED: Use something else instead"
-  deprecated1: String
-  deprecated2: String @deprecated
-  deprecated3: String @deprecated(reason: "Deprecated directive works too")
-  "DEPRECATED: It only takes the first one"
-  deprecated4: String
-    @deprecated(reason: "when you have multiple deprecated annotations")
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Use `@GraphQLDescription` instead of `@Deprecated` on fields with union types until the related bug is fixed.

### :link: Related Issues
- https://github.com/ExpediaGroup/graphql-kotlin/issues/1941
