### PR TITLE
feat: support graphql-kotlin ID scalar

### DIFF
--- a/src/helpers/build-type-metadata.ts
+++ b/src/helpers/build-type-metadata.ts
@@ -100,7 +100,7 @@ export function buildListType(typeNode: TypeNode, typeName: string) {
 export const KOTLIN_SCALARS = [
   {
     scalarName: "ID",
-    kotlinType: "String",
+    kotlinType: "com.expediagroup.graphql.generator.scalars.ID",
   },
   {
     scalarName: "String",

--- a/test/unit/should_support_custom_scalars/expected.kt
+++ b/test/unit/should_support_custom_scalars/expected.kt
@@ -3,6 +3,7 @@ package com.kotlin.generated
 import com.expediagroup.graphql.generator.annotations.*
 
 data class MyScalarType(
+    val idField: com.expediagroup.graphql.generator.scalars.ID? = null,
     val field: URL? = null,
     val field2: URL
 )

--- a/test/unit/should_support_custom_scalars/schema.graphql
+++ b/test/unit/should_support_custom_scalars/schema.graphql
@@ -1,6 +1,7 @@
 scalar URL
 
 type MyScalarType {
+  idField: ID
   field: URL
   field2: URL!
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Convert the GraphQL `ID` type to the [GraphQL Kotlin ID scalar](https://opensource.expediagroup.com/graphql-kotlin/docs/schema-generator/writing-schemas/scalars/#graphql-id) by default.
