### PR TITLE
fix: trim union descriptions

### DIFF
--- a/src/definitions/union.ts
+++ b/src/definitions/union.ts
@@ -15,6 +15,7 @@ import { UnionTypeDefinitionNode } from "graphql";
 import { shouldIncludeTypeDefinition } from "../helpers/should-include-type-definition";
 import { buildDirectiveAnnotations } from "../helpers/build-directive-annotations";
 import { CodegenConfig } from "../plugin";
+import { trimDescription } from "../helpers/build-annotations";
 
 export function buildUnionTypeDefinition(
   node: UnionTypeDefinitionNode,
@@ -30,7 +31,7 @@ export function buildUnionTypeDefinition(
   return `${directiveAnnotations}@GraphQLUnion(
     name = "${node.name.value}",
     possibleTypes = [${possibleTypes}],
-    description = "${node.description?.value ?? ""}"
+    description = "${node.description?.value ? trimDescription(node.description.value) : ""}"
 )
 annotation class ${node.name.value}`;
 }

--- a/src/helpers/build-annotations.ts
+++ b/src/helpers/build-annotations.ts
@@ -95,7 +95,7 @@ export function isDeprecatedDescription(
   );
 }
 
-function trimDescription(description: string) {
+export function trimDescription(description: string) {
   return (
     description
       .split("\n")

--- a/test/unit/should_generate_union_types_properly/expected.kt
+++ b/test/unit/should_generate_union_types_properly/expected.kt
@@ -14,7 +14,7 @@ data class MyType2(
 @GraphQLUnion(
     name = "MyUnion",
     possibleTypes = [MyType1::class, MyType2::class],
-    description = "A description for MyUnion"
+    description = "A trimmed description for MyUnion"
 )
 annotation class MyUnion
 

--- a/test/unit/should_generate_union_types_properly/schema.graphql
+++ b/test/unit/should_generate_union_types_properly/schema.graphql
@@ -7,7 +7,9 @@ type MyType2 {
   field: String
 }
 
-"A description for MyUnion"
+"""
+A "trimmed" description for MyUnion
+"""
 union MyUnion = MyType1 | MyType2
 
 type MyUnionType {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Applies same description trimming to union annotation descriptions.
