### PR TITLE
fix: duplicated description annotation on union fields

### DIFF
--- a/src/helpers/build-directive-annotations.ts
+++ b/src/helpers/build-directive-annotations.ts
@@ -39,6 +39,9 @@ export function buildDirectiveAnnotations(
           deprecatedReasonNode?.kind === "StringValue"
             ? deprecatedReasonNode.value
             : "";
+        if (incomingNode.description?.value && resolvedType?.unionAnnotation) {
+          return "";
+        }
         const descriptionAnnotator = resolvedType?.unionAnnotation
           ? "@GraphQLDescription"
           : "@Deprecated";

--- a/test/unit/should_annotate_types_properly/expected.kt
+++ b/test/unit/should_annotate_types_properly/expected.kt
@@ -25,7 +25,6 @@ data class MyType(
     val deprecated6: Any? = null,
     @MyUnion
     @GraphQLDescription("When there is a description")
-    @Deprecated("It puts the deprecated reason in @Deprecated")
     val deprecated7: Any? = null
 )
 

--- a/test/unit/should_annotate_types_properly/expected.kt
+++ b/test/unit/should_annotate_types_properly/expected.kt
@@ -22,7 +22,11 @@ data class MyType(
     val deprecated5: Any? = null,
     @MyUnion
     @GraphQLDescription("It uses the GraphQLDescription annotation for union types")
-    val deprecated6: Any? = null
+    val deprecated6: Any? = null,
+    @MyUnion
+    @GraphQLDescription("When there is a description")
+    @Deprecated("It puts the deprecated reason in @Deprecated")
+    val deprecated7: Any? = null
 )
 
 @GraphQLUnion(

--- a/test/unit/should_annotate_types_properly/schema.graphql
+++ b/test/unit/should_annotate_types_properly/schema.graphql
@@ -24,6 +24,9 @@ type MyType {
     @deprecated(
       reason: "It uses the GraphQLDescription annotation for union types"
     )
+  "When there is a description"
+  deprecated7: MyUnion
+    @deprecated(reason: "It puts the deprecated reason in @Deprecated")
 }
 
 union MyUnion = MyType

--- a/test/unit/should_annotate_types_properly/schema.graphql
+++ b/test/unit/should_annotate_types_properly/schema.graphql
@@ -26,7 +26,7 @@ type MyType {
     )
   "When there is a description"
   deprecated7: MyUnion
-    @deprecated(reason: "It puts the deprecated reason in @Deprecated")
+    @deprecated(reason: "It omits the @Deprecated annotation for now")
 }
 
 union MyUnion = MyType


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Fixes a bug where duplicated `@GraphQLDescription` annotations were possible on fields with union types.

### :link: Related Issues
- https://github.com/ExpediaGroup/graphql-kotlin-codegen/issues/26