### PR TITLE
feat: include DataFetchingEnvironment in all resolver interface functions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -111,6 +111,7 @@ export const configSchema = object({
   /**
    * Denotes extra arguments that should be added to functions on resolver classes.
    * @example [{ typeNames: ["MyType", "MyType2"], argumentName: "myArgument", argumentValue: "myValue" }]
+   * @deprecated This will be removed in a future release now that DataFetchingEnvironment is added to functions by default.
    */
   extraResolverArguments: optional(
     array(

--- a/src/helpers/build-config-with-defaults.ts
+++ b/src/helpers/build-config-with-defaults.ts
@@ -15,7 +15,14 @@ export function buildConfigWithDefaults(
       "com.expediagroup.graphql.generator.annotations.*",
       ...(config.extraImports ?? []),
     ],
-  } as const;
+    extraResolverArguments: [
+      {
+        argumentName: "dataFetchingEnvironment",
+        argumentType: "graphql.schema.DataFetchingEnvironment",
+      },
+      ...(config.extraResolverArguments ?? []),
+    ],
+  } as const satisfies GraphQLKotlinCodegenConfig;
 }
 
 export type CodegenConfigWithDefaults = ReturnType<

--- a/src/helpers/build-field-definition.ts
+++ b/src/helpers/build-field-definition.ts
@@ -42,11 +42,17 @@ export function buildFieldDefinition(
     return `${arg.name.value}: ${typeMetadata.typeName}${arg.type.kind === Kind.NON_NULL_TYPE ? "" : "?"}`;
   });
   const additionalFieldArguments = config.extraResolverArguments
-    ?.map(({ typeNames, argumentType, argumentName }) => {
+    ?.map((resolverArgument) => {
+      const { argumentName, argumentType } = resolverArgument;
       const shouldIncludeArg =
-        !typeNames ||
-        typeNames.some((typeName) => typeName === definitionNode.name.value);
-      return shouldIncludeArg ? `${argumentName}: ${argumentType}` : undefined;
+        !("typeNames" in resolverArgument) ||
+        !resolverArgument.typeNames ||
+        resolverArgument.typeNames.some(
+          (typeName) => typeName === definitionNode.name.value,
+        );
+      return shouldUseFunction && shouldIncludeArg
+        ? `${argumentName}: ${argumentType}`
+        : undefined;
     })
     .filter(Boolean);
   const allFieldArguments = existingFieldArguments?.concat(

--- a/test/unit/should_consolidate_input_and_output_types/expected.kt
+++ b/test/unit/should_consolidate_input_and_output_types/expected.kt
@@ -70,12 +70,12 @@ data class MyTypeToConsolidateInputParent(
 
 @GraphQLIgnore
 interface MyTypeToConsolidateParent2 {
-    suspend fun field(input: MyTypeToConsolidate): String? = null
+    suspend fun field(input: MyTypeToConsolidate, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
 }
 
 @GraphQLIgnore
 interface MyTypeToConsolidateParent2CompletableFuture {
-    fun field(input: MyTypeToConsolidate): java.util.concurrent.CompletableFuture<String?>
+    fun field(input: MyTypeToConsolidate, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
 }
 
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])

--- a/test/unit/should_generate_field_resolver_interfaces/expected.kt
+++ b/test/unit/should_generate_field_resolver_interfaces/expected.kt
@@ -4,18 +4,18 @@ import com.expediagroup.graphql.generator.annotations.*
 
 @GraphQLIgnore
 interface Query {
-    suspend fun nullableField(): FieldType? = null
-    suspend fun nonNullableField(): FieldType
-    suspend fun nullableResolver(arg: String): String? = null
-    suspend fun nonNullableResolver(arg: InputTypeGenerateFieldResolverInterfaces): String
+    suspend fun nullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): FieldType? = null
+    suspend fun nonNullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): FieldType
+    suspend fun nullableResolver(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
+    suspend fun nonNullableResolver(arg: InputTypeGenerateFieldResolverInterfaces, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
 }
 
 @GraphQLIgnore
 interface QueryCompletableFuture {
-    fun nullableField(): java.util.concurrent.CompletableFuture<FieldType?>
-    fun nonNullableField(): java.util.concurrent.CompletableFuture<FieldType>
-    fun nullableResolver(arg: String): java.util.concurrent.CompletableFuture<String?>
-    fun nonNullableResolver(arg: InputTypeGenerateFieldResolverInterfaces): java.util.concurrent.CompletableFuture<String>
+    fun nullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<FieldType?>
+    fun nonNullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<FieldType>
+    fun nullableResolver(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
+    fun nonNullableResolver(arg: InputTypeGenerateFieldResolverInterfaces, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String>
 }
 
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.INPUT_OBJECT])
@@ -24,32 +24,32 @@ data class InputTypeGenerateFieldResolverInterfaces(
 )
 
 interface MyFieldInterface {
-    suspend fun field1(): String?
-    suspend fun field2(): String
-    suspend fun nullableListResolver(arg1: Int?, arg2: Int): List<String?>?
-    suspend fun nonNullableListResolver(arg1: Int, arg2: Int?): List<String>
+    suspend fun field1(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String?
+    suspend fun field2(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
+    suspend fun nullableListResolver(arg1: Int?, arg2: Int, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): List<String?>?
+    suspend fun nonNullableListResolver(arg1: Int, arg2: Int?, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): List<String>
 }
 
 @GraphQLIgnore
 interface FieldType : MyFieldInterface {
-    override suspend fun field1(): String? = null
-    override suspend fun field2(): String
-    suspend fun booleanField1(): Boolean? = null
-    suspend fun booleanField2(): Boolean = false
-    suspend fun integerField1(): Int? = null
-    suspend fun integerField2(): Int
-    override suspend fun nullableListResolver(arg1: Int?, arg2: Int): List<String?>? = null
-    override suspend fun nonNullableListResolver(arg1: Int, arg2: Int?): List<String> = emptyList()
+    override suspend fun field1(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
+    override suspend fun field2(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
+    suspend fun booleanField1(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): Boolean? = null
+    suspend fun booleanField2(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): Boolean = false
+    suspend fun integerField1(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): Int? = null
+    suspend fun integerField2(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): Int
+    override suspend fun nullableListResolver(arg1: Int?, arg2: Int, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): List<String?>? = null
+    override suspend fun nonNullableListResolver(arg1: Int, arg2: Int?, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): List<String> = emptyList()
 }
 
 @GraphQLIgnore
 interface FieldTypeCompletableFuture {
-    fun field1(): java.util.concurrent.CompletableFuture<String?>
-    fun field2(): java.util.concurrent.CompletableFuture<String>
-    fun booleanField1(): java.util.concurrent.CompletableFuture<Boolean?>
-    fun booleanField2(): java.util.concurrent.CompletableFuture<Boolean>
-    fun integerField1(): java.util.concurrent.CompletableFuture<Int?>
-    fun integerField2(): java.util.concurrent.CompletableFuture<Int>
-    fun nullableListResolver(arg1: Int?, arg2: Int): java.util.concurrent.CompletableFuture<List<String?>?>
-    fun nonNullableListResolver(arg1: Int, arg2: Int?): java.util.concurrent.CompletableFuture<List<String>>
+    fun field1(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
+    fun field2(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String>
+    fun booleanField1(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<Boolean?>
+    fun booleanField2(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<Boolean>
+    fun integerField1(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<Int?>
+    fun integerField2(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<Int>
+    fun nullableListResolver(arg1: Int?, arg2: Int, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<List<String?>?>
+    fun nonNullableListResolver(arg1: Int, arg2: Int?, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<List<String>>
 }

--- a/test/unit/should_honor_extraResolverArguments_config/codegen.config.ts
+++ b/test/unit/should_honor_extraResolverArguments_config/codegen.config.ts
@@ -4,8 +4,8 @@ export default {
   resolverTypes: ["MyIncludedExtraFieldArgsType"],
   extraResolverArguments: [
     {
-      argumentName: "dataFetchingEnvironment",
-      argumentType: "graphql.schema.DataFetchingEnvironment",
+      argumentName: "myExtraFieldArg",
+      argumentType: "String",
       typeNames: ["MyExtraFieldArgsType", "MyIncludedExtraFieldArgsType"],
     },
   ],

--- a/test/unit/should_honor_extraResolverArguments_config/expected.kt
+++ b/test/unit/should_honor_extraResolverArguments_config/expected.kt
@@ -4,36 +4,36 @@ import com.expediagroup.graphql.generator.annotations.*
 
 @GraphQLIgnore
 interface MyExtraFieldArgsType {
-    suspend fun myField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
-    suspend fun fieldWithArgs(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
+    suspend fun myField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment, myExtraFieldArg: String): String? = null
+    suspend fun fieldWithArgs(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment, myExtraFieldArg: String): String
 }
 
 @GraphQLIgnore
 interface MyExtraFieldArgsTypeCompletableFuture {
-    fun myField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
-    fun fieldWithArgs(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String>
+    fun myField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment, myExtraFieldArg: String): java.util.concurrent.CompletableFuture<String?>
+    fun fieldWithArgs(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment, myExtraFieldArg: String): java.util.concurrent.CompletableFuture<String>
 }
 
 @GraphQLIgnore
 interface MyIncludedExtraFieldArgsType {
-    suspend fun myField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
-    suspend fun myOtherField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
+    suspend fun myField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment, myExtraFieldArg: String): String? = null
+    suspend fun myOtherField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment, myExtraFieldArg: String): String? = null
 }
 
 @GraphQLIgnore
 interface MyIncludedExtraFieldArgsTypeCompletableFuture {
-    fun myField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
-    fun myOtherField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
+    fun myField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment, myExtraFieldArg: String): java.util.concurrent.CompletableFuture<String?>
+    fun myOtherField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment, myExtraFieldArg: String): java.util.concurrent.CompletableFuture<String?>
 }
 
 @GraphQLIgnore
 interface MyOtherType {
-    suspend fun myField(arg: String): String
-    suspend fun myOtherField(): String? = null
+    suspend fun myField(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
+    suspend fun myOtherField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
 }
 
 @GraphQLIgnore
 interface MyOtherTypeCompletableFuture {
-    fun myField(arg: String): java.util.concurrent.CompletableFuture<String>
-    fun myOtherField(): java.util.concurrent.CompletableFuture<String?>
+    fun myField(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String>
+    fun myOtherField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
 }

--- a/test/unit/should_honor_resolverTypes_config/expected.kt
+++ b/test/unit/should_honor_resolverTypes_config/expected.kt
@@ -4,30 +4,30 @@ import com.expediagroup.graphql.generator.annotations.*
 
 @GraphQLIgnore
 interface MyResolverType {
-    suspend fun nullableField(): String? = null
-    suspend fun nonNullableField(): String
-    suspend fun nullableResolver(arg: String): String? = null
-    suspend fun nonNullableResolver(arg: String): String
+    suspend fun nullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
+    suspend fun nonNullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
+    suspend fun nullableResolver(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
+    suspend fun nonNullableResolver(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
 }
 
 @GraphQLIgnore
 interface MyResolverTypeCompletableFuture {
-    fun nullableField(): java.util.concurrent.CompletableFuture<String?>
-    fun nonNullableField(): java.util.concurrent.CompletableFuture<String>
-    fun nullableResolver(arg: String): java.util.concurrent.CompletableFuture<String?>
-    fun nonNullableResolver(arg: String): java.util.concurrent.CompletableFuture<String>
+    fun nullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
+    fun nonNullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String>
+    fun nullableResolver(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
+    fun nonNullableResolver(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String>
 }
 
 @GraphQLIgnore
 interface MyIncludedResolverType {
-    suspend fun nullableField(): String? = null
-    suspend fun nonNullableField(): String
+    suspend fun nullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
+    suspend fun nonNullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
 }
 
 @GraphQLIgnore
 interface MyIncludedResolverTypeCompletableFuture {
-    fun nullableField(): java.util.concurrent.CompletableFuture<String?>
-    fun nonNullableField(): java.util.concurrent.CompletableFuture<String>
+    fun nullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?>
+    fun nonNullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String>
 }
 
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
@@ -37,7 +37,7 @@ data class MyExcludedResolverType(
 )
 
 interface MyIncludedInterface {
-    suspend fun field(): String?
+    suspend fun field(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String?
 }
 
 interface MyExcludedInterface {

--- a/test/unit/should_replace_federation_directives/expected.kt
+++ b/test/unit/should_replace_federation_directives/expected.kt
@@ -14,7 +14,7 @@ data class FederatedType(
 @com.expediagroup.graphql.generator.federation.directives.KeyDirective(com.expediagroup.graphql.generator.federation.directives.FieldSet("some other field"))
 @GraphQLIgnore
 interface FederatedTypeResolver {
-    suspend fun field(arg: String): String
+    suspend fun field(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String
     @com.expediagroup.graphql.generator.federation.directives.ExternalDirective
     val field2: String?
 }
@@ -23,7 +23,7 @@ interface FederatedTypeResolver {
 @com.expediagroup.graphql.generator.federation.directives.KeyDirective(com.expediagroup.graphql.generator.federation.directives.FieldSet("some other field"))
 @GraphQLIgnore
 interface FederatedTypeResolverCompletableFuture {
-    fun field(arg: String): java.util.concurrent.CompletableFuture<String>
+    fun field(arg: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String>
     @com.expediagroup.graphql.generator.federation.directives.ExternalDirective
     val field2: java.util.concurrent.CompletableFuture<String?>
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- By default, include [DataFetchingEnvironment](https://opensource.expediagroup.com/graphql-kotlin/docs/schema-generator/execution/data-fetching-environment) as an additional argument to resolver functions, since all resolvers should have access to this.