### PR TITLE
fix: class consolidation with enum child types

### DIFF
--- a/src/helpers/input-type-has-matching-output-type.ts
+++ b/src/helpers/input-type-has-matching-output-type.ts
@@ -30,7 +30,12 @@ function typesAreEquivalent(
 ): boolean {
   const typeNode = schema.getType(typeName);
   const inputNode = schema.getType(inputName);
-  if (!typeNode?.astNode && !inputNode?.astNode) {
+
+  if (
+    !isObjectType(typeNode) &&
+    !isInputObjectType(inputNode) &&
+    typeNode?.astNode?.kind === inputNode?.astNode?.kind
+  ) {
     return true;
   }
   if (

--- a/test/unit/should_consolidate_input_and_output_types/expected.kt
+++ b/test/unit/should_consolidate_input_and_output_types/expected.kt
@@ -106,3 +106,25 @@ data class MySuperSetTypeInput(
     val field2: String? = null,
     val field3: Int? = null
 )
+
+data class MyTypeWithEnums(
+    val field1: List<Enum1>? = null,
+    val field2: List<Enum2>? = null
+)
+
+enum class Enum1 {
+    This,
+    That;
+
+    companion object {
+        fun findByName(name: String, ignoreCase: Boolean = false): Enum1? = values().find { it.name.equals(name, ignoreCase = ignoreCase) }
+    }
+}
+
+enum class Enum2 {
+    The_Other;
+
+    companion object {
+        fun findByName(name: String, ignoreCase: Boolean = false): Enum2? = values().find { it.name.equals(name, ignoreCase = ignoreCase) }
+    }
+}

--- a/test/unit/should_consolidate_input_and_output_types/schema.graphql
+++ b/test/unit/should_consolidate_input_and_output_types/schema.graphql
@@ -130,3 +130,22 @@ input MySuperSetTypeInput {
   field2: String
   field3: Int
 }
+
+type MyTypeWithEnums {
+  field1: [Enum1!]
+  field2: [Enum2!]
+}
+
+input MyTypeWithEnumsInput {
+  field1: [Enum1!]
+  field2: [Enum2!]
+}
+
+enum Enum1 {
+  THIS
+  THAT
+}
+
+enum Enum2 {
+  THE_OTHER
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Fixes a bug where classes where not being consolidated in cases where input and output types share common enum fields.
