### PR TITLE
fix: rename top level generated interfaces to be more explicit

### DIFF
--- a/docs/docs/inheritance.md
+++ b/docs/docs/inheritance.md
@@ -114,8 +114,8 @@ Instead, you should inherit from the field-level generated `Query` classes like 
 
 ```kotlin
 import com.expediagroup.graphql.server.operations.Query
-import com.types.generated.FooQuery as FooQueryInterface
-import com.types.generated.BarQuery as BarQueryInterface
+import com.types.generated.FooQueryInterface
+import com.types.generated.BarQueryInterface
 
 class FooQuery : Query, FooQueryInterface() {
   override fun foo(): String = "Hello"

--- a/src/definitions/object.ts
+++ b/src/definitions/object.ts
@@ -77,7 +77,7 @@ export function buildObjectTypeDefinition(
     node.name.value === "Query" || node.name.value === "Mutation";
   if (isTopLevelType) {
     const individualQueryClasses = node.fields?.map((fieldNode) => {
-      const className = `${titleCase(fieldNode.name.value)}${node.name.value}`;
+      const className = `${titleCase(fieldNode.name.value)}${node.name.value}Interface`;
       return `${annotations}${outputRestrictionAnnotation}open class ${className}${interfaceInheritance} {
 ${getClassMembers({ node, fieldNodes: [fieldNode], schema, config })}
 }`;

--- a/test/unit/should_handle_top_level_types_properly/expected.kt
+++ b/test/unit/should_handle_top_level_types_properly/expected.kt
@@ -9,12 +9,12 @@ open class Query {
 }
 
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
-open class GetStuffQuery {
+open class GetStuffQueryInterface {
     open fun getStuff(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("Query.getStuff must be implemented.")
 }
 
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
-open class GetStuffWithInputQuery {
+open class GetStuffWithInputQueryInterface {
     open fun getStuffWithInput(input: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("Query.getStuffWithInput must be implemented.")
 }
 
@@ -25,11 +25,11 @@ open class Mutation {
 }
 
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
-open class MutateStuffMutation {
+open class MutateStuffMutationInterface {
     open suspend fun mutateStuff(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("Mutation.mutateStuff must be implemented.")
 }
 
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
-open class MutateStuffWithInputMutation {
+open class MutateStuffWithInputMutationInterface {
     open suspend fun mutateStuffWithInput(input: String, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("Mutation.mutateStuffWithInput must be implemented.")
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Tacks on `Interface` to the end of field-level Query and Mutation interface class names.
