### PR TITLE
feat: allow nullable dataFetchingEnvironment in resolver functions

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -112,7 +112,8 @@ export const configSchema = object({
    * interface functions to enforce a type contract.
    *
    * Type names can be optionally passed with the classMethods config to generate the interface with `suspend` functions or
-   * `java.util.concurrent.CompletableFuture` functions.
+   * `java.util.concurrent.CompletableFuture` functions. Pass `nullableDataFetchingEnvironment: true` to make the
+   * `DataFetchingEnvironment` argument nullable in each resolver function for that class.
    * @example
    * [
    *   {
@@ -125,6 +126,10 @@ export const configSchema = object({
    *   {
    *     typeName: "MyCompletableFutureResolverType",
    *     classMethods: "COMPLETABLE_FUTURE",
+   *   },
+   *   {
+   *     typeName: "MyTypeWithNullableDataFetchingEnvironment",
+   *     nullableDataFetchingEnvironment: true,
    *   }
    * ]
    * @link https://opensource.expediagroup.com/graphql-kotlin-codegen/docs/recommended-usage
@@ -136,6 +141,7 @@ export const configSchema = object({
         classMethods: optional(
           union([literal("SUSPEND"), literal("COMPLETABLE_FUTURE")]),
         ),
+        nullableDataFetchingEnvironment: optional(boolean()),
       }),
     ),
   ),

--- a/src/definitions/field.ts
+++ b/src/definitions/field.ts
@@ -287,8 +287,7 @@ function buildFieldArguments(
     const argMetadata = buildTypeMetadata(arg.type, schema, config);
     return `${sanitizeName(arg.name.value)}: ${argMetadata.typeName}${arg.type.kind === Kind.NON_NULL_TYPE ? "" : nullableSuffix}`;
   });
-  const dataFetchingEnvironmentArgument =
-    "dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment";
+  const dataFetchingEnvironmentArgument = `dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment${typeInResolverInterfacesConfig?.nullableDataFetchingEnvironment ? "? = null" : ""}`;
   const extraFieldArguments = [dataFetchingEnvironmentArgument];
   const allFieldArguments = existingFieldArguments?.concat(extraFieldArguments);
   return allFieldArguments?.length

--- a/test/unit/should_honor_resolverInterfaces_config/codegen.config.ts
+++ b/test/unit/should_honor_resolverInterfaces_config/codegen.config.ts
@@ -23,5 +23,9 @@ export default {
       typeName: "MyIncludedInterfaceSuspend",
       classMethods: "SUSPEND",
     },
+    {
+      typeName: "MyIncludedResolverTypeWithNullDataFetchingEnvironment",
+      nullableDataFetchingEnvironment: true,
+    },
   ],
 } satisfies GraphQLKotlinCodegenConfig;

--- a/test/unit/should_honor_resolverInterfaces_config/expected.kt
+++ b/test/unit/should_honor_resolverInterfaces_config/expected.kt
@@ -63,3 +63,9 @@ interface MyIncludedInterfaceSuspend {
 interface MyExcludedInterface {
     val field: String?
 }
+
+@GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
+open class MyIncludedResolverTypeWithNullDataFetchingEnvironment {
+    open fun nullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment? = null): String? = throw NotImplementedError("MyIncludedResolverTypeWithNullDataFetchingEnvironment.nullableField must be implemented.")
+    open fun nonNullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment? = null): String = throw NotImplementedError("MyIncludedResolverTypeWithNullDataFetchingEnvironment.nonNullableField must be implemented.")
+}

--- a/test/unit/should_honor_resolverInterfaces_config/schema.graphql
+++ b/test/unit/should_honor_resolverInterfaces_config/schema.graphql
@@ -51,3 +51,8 @@ interface MyIncludedInterfaceSuspend {
 interface MyExcludedInterface {
   field: String
 }
+
+type MyIncludedResolverTypeWithNullDataFetchingEnvironment {
+  nullableField: String
+  nonNullableField: String!
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Adds a `nullableDataFetchingEnvironment` config which allows resolver function interfaces to contain the argument `dataFetchingEnvironment: DataFetchingEnvironment? = null`.