### PR TITLE
fix: ignore directive replacements for consolidated types when definitionType is input/output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expediagroup/graphql-kotlin-codegen",
-  "packageManager": "bun@1.1.17",
+  "packageManager": "bun@1.1.32",
   "main": "dist/plugin.cjs",
   "types": "dist/plugin.d.cts",
   "files": [

--- a/src/annotations/build-annotations.ts
+++ b/src/annotations/build-annotations.ts
@@ -15,6 +15,7 @@ import { indent } from "@graphql-codegen/visitor-plugin-common";
 import {
   EnumValueDefinitionNode,
   FieldDefinitionNode,
+  GraphQLSchema,
   InputValueDefinitionNode,
   Kind,
   TypeDefinitionNode,
@@ -31,10 +32,12 @@ export type DefinitionNode =
   | EnumValueDefinitionNode;
 
 export function buildAnnotations({
+  schema,
   config,
   definitionNode,
   typeMetadata,
 }: {
+  schema: GraphQLSchema;
   config: CodegenConfigWithDefaults;
   definitionNode: DefinitionNode;
   typeMetadata?: TypeMetadata;
@@ -49,6 +52,7 @@ export function buildAnnotations({
   const directiveAnnotations = buildDirectiveAnnotations(
     definitionNode,
     config,
+    schema,
   );
   const unionAnnotation = typeMetadata?.unionAnnotation
     ? `@${typeMetadata.unionAnnotation}\n`

--- a/src/definitions/enum.ts
+++ b/src/definitions/enum.ts
@@ -17,9 +17,11 @@ import { buildAnnotations } from "../annotations/build-annotations";
 import { shouldExcludeTypeDefinition } from "../config/should-exclude-type-definition";
 import { CodegenConfigWithDefaults } from "../config/build-config-with-defaults";
 import { sanitizeName } from "../utils/sanitize-name";
+import { GraphQLSchema } from "graphql";
 
 export function buildEnumTypeDefinition(
   node: EnumTypeDefinitionNode,
+  schema: GraphQLSchema,
   config: CodegenConfigWithDefaults,
 ) {
   if (shouldExcludeTypeDefinition(node, config)) {
@@ -29,10 +31,11 @@ export function buildEnumTypeDefinition(
   const enumName = sanitizeName(node.name.value);
   const enumValues =
     node.values?.map((valueNode) => {
-      return buildEnumValueDefinition(valueNode, config);
+      return buildEnumValueDefinition(valueNode, schema, config);
     }) ?? [];
 
   const annotations = buildAnnotations({
+    schema,
     config,
     definitionNode: node,
   });
@@ -47,10 +50,12 @@ ${indentMultiline(enumValues.join(",\n") + ";", 2)}
 
 function buildEnumValueDefinition(
   node: EnumValueDefinitionNode,
+  schema: GraphQLSchema,
   config: CodegenConfigWithDefaults,
 ) {
   const annotations = buildAnnotations({
     config,
+    schema,
     definitionNode: node,
   });
   if (!config.convert) {

--- a/src/definitions/field.ts
+++ b/src/definitions/field.ts
@@ -72,6 +72,7 @@ export function buildObjectFieldDefinition({
     typeMetadata,
   );
   const annotations = buildAnnotations({
+    schema,
     config,
     definitionNode: fieldNode,
     typeMetadata,
@@ -112,6 +113,7 @@ export function buildConstructorFieldDefinition({
     typeMetadata,
   );
   const annotations = buildAnnotations({
+    schema,
     config,
     definitionNode: fieldNode,
     typeMetadata,
@@ -156,6 +158,7 @@ export function buildInterfaceFieldDefinition({
     typeMetadata,
   );
   const annotations = buildAnnotations({
+    schema,
     config,
     definitionNode: fieldNode,
     typeMetadata,

--- a/src/definitions/input.ts
+++ b/src/definitions/input.ts
@@ -40,6 +40,7 @@ export function buildInputObjectDefinition(
       const initial = typeToUse.isNullable ? " = null" : "";
 
       const annotations = buildAnnotations({
+        schema,
         config,
         definitionNode: field,
       });
@@ -53,6 +54,7 @@ export function buildInputObjectDefinition(
     .join(",\n");
 
   const annotations = buildAnnotations({
+    schema,
     config,
     definitionNode: node,
   });

--- a/src/definitions/interface.ts
+++ b/src/definitions/interface.ts
@@ -40,6 +40,7 @@ export function buildInterfaceDefinition(
     .join("\n");
 
   const annotations = buildAnnotations({
+    schema,
     config,
     definitionNode: node,
   });

--- a/src/definitions/object.ts
+++ b/src/definitions/object.ts
@@ -42,10 +42,10 @@ export function buildObjectTypeDefinition(
   }
 
   const annotations = buildAnnotations({
+    schema,
     config,
     definitionNode: node,
   });
-  const name = sanitizeName(node.name.value);
   const dependentInterfaces = getDependentInterfaceNames(node);
   const dependentUnions = getDependentUnionsForType(schema, node);
   const interfacesToInherit =
@@ -57,6 +57,7 @@ export function buildObjectTypeDefinition(
   );
   const interfaceInheritance = `${interfacesToInherit.length ? ` : ${sanitizedInterfaceNames.join(", ")}` : ""}`;
 
+  const name = sanitizeName(node.name.value);
   const potentialMatchingInputType = schema.getType(`${name}Input`);
   const typeWillBeConsolidated =
     isInputObjectType(potentialMatchingInputType) &&

--- a/src/definitions/union.ts
+++ b/src/definitions/union.ts
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { UnionTypeDefinitionNode } from "graphql";
+import { GraphQLSchema, UnionTypeDefinitionNode } from "graphql";
 import { shouldExcludeTypeDefinition } from "../config/should-exclude-type-definition";
 import { CodegenConfigWithDefaults } from "../config/build-config-with-defaults";
 import {
@@ -22,12 +22,14 @@ import { sanitizeName } from "../utils/sanitize-name";
 
 export function buildUnionTypeDefinition(
   node: UnionTypeDefinitionNode,
+  schema: GraphQLSchema,
   config: CodegenConfigWithDefaults,
 ) {
   if (shouldExcludeTypeDefinition(node, config)) {
     return "";
   }
   const annotations = buildAnnotations({
+    schema,
     config,
     definitionNode: node,
   });

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -40,7 +40,7 @@ export class KotlinVisitor extends BaseVisitor<
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {
-    return buildEnumTypeDefinition(node, this.config);
+    return buildEnumTypeDefinition(node, this._schema, this.config);
   }
 
   InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode): string {
@@ -56,6 +56,6 @@ export class KotlinVisitor extends BaseVisitor<
   }
 
   UnionTypeDefinition(node: UnionTypeDefinitionNode): string {
-    return buildUnionTypeDefinition(node, this.config);
+    return buildUnionTypeDefinition(node, this._schema, this.config);
   }
 }

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/codegen.config.ts
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/codegen.config.ts
@@ -12,7 +12,6 @@ export default {
     {
       directive: "directive2",
       kotlinAnnotations: ["@SomeAnnotation2"],
-      definitionType: Kind.ENUM_TYPE_DEFINITION,
     },
   ],
   classConsolidationEnabled: true,

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/codegen.config.ts
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/codegen.config.ts
@@ -1,0 +1,14 @@
+import { GraphQLKotlinCodegenConfig } from "../../../src/plugin";
+import { Kind } from "graphql/index";
+
+export default {
+  extraImports: ["should_honor_directiveReplacements_config.*"],
+  directiveReplacements: [
+    {
+      directive: "directive1",
+      kotlinAnnotations: ["@SomeAnnotation1"],
+      definitionType: Kind.OBJECT_TYPE_DEFINITION,
+    },
+  ],
+  classConsolidationEnabled: true,
+} satisfies GraphQLKotlinCodegenConfig;

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/codegen.config.ts
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/codegen.config.ts
@@ -9,6 +9,11 @@ export default {
       kotlinAnnotations: ["@SomeAnnotation1"],
       definitionType: Kind.OBJECT_TYPE_DEFINITION,
     },
+    {
+      directive: "directive2",
+      kotlinAnnotations: ["@SomeAnnotation2"],
+      definitionType: Kind.ENUM_TYPE_DEFINITION,
+    },
   ],
   classConsolidationEnabled: true,
 } satisfies GraphQLKotlinCodegenConfig;

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
@@ -6,7 +6,7 @@ import should_honor_directiveReplacements_config.*
 @SomeAnnotation1
 @SomeAnnotation2
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
-data class TypeThatShouldGetDirectiveReplacement(
+data class TypeHonoringDirectiveReplacementsDefinitionType(
     val field: String? = null
 )
 

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
@@ -1,0 +1,19 @@
+package com.kotlin.generated
+
+import com.expediagroup.graphql.generator.annotations.*
+import should_honor_directiveReplacements_config.*
+
+@SomeAnnotation1
+@GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
+data class TypeHonoringDirectiveReplacementsDefinitionType(
+    val field: String? = null
+)
+
+@GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.INPUT_OBJECT])
+data class InputTypeThatShouldNotGetDirectiveReplacement(
+    val field: String? = null
+)
+
+data class MyDirectiveConsolidatedType(
+    val field: String? = null
+)

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
@@ -14,6 +14,15 @@ data class InputTypeThatShouldNotGetDirectiveReplacement(
     val field: String? = null
 )
 
-data class MyDirectiveConsolidatedType(
+@SomeAnnotation2
+enum class MyEnumWithDirectives {
+    Value;
+
+    companion object {
+        fun findByName(name: String, ignoreCase: Boolean = false): MyEnumWithDirectives? = values().find { it.name.equals(name, ignoreCase = ignoreCase) }
+    }
+}
+
+data class MyConsolidatedTypeWithDirectives(
     val field: String? = null
 )

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
@@ -4,25 +4,23 @@ import com.expediagroup.graphql.generator.annotations.*
 import should_honor_directiveReplacements_config.*
 
 @SomeAnnotation1
+@SomeAnnotation2
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
 data class TypeHonoringDirectiveReplacementsDefinitionType(
     val field: String? = null
 )
 
+@SomeAnnotation2
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.INPUT_OBJECT])
 data class InputTypeThatShouldNotGetDirectiveReplacement(
     val field: String? = null
 )
 
-@SomeAnnotation2
-enum class MyEnumWithDirectives {
-    Value;
-
-    companion object {
-        fun findByName(name: String, ignoreCase: Boolean = false): MyEnumWithDirectives? = values().find { it.name.equals(name, ignoreCase = ignoreCase) }
-    }
-}
-
 data class MyConsolidatedTypeWithDirectives(
+    val field: String? = null
+)
+
+@SomeAnnotation2
+data class MyConsolidatedTypeWithDirectives2(
     val field: String? = null
 )

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/expected.kt
@@ -6,7 +6,7 @@ import should_honor_directiveReplacements_config.*
 @SomeAnnotation1
 @SomeAnnotation2
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
-data class TypeHonoringDirectiveReplacementsDefinitionType(
+data class TypeThatShouldGetDirectiveReplacement(
     val field: String? = null
 )
 

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/schema.graphql
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/schema.graphql
@@ -1,5 +1,5 @@
 directive @directive1 on INPUT_OBJECT | OBJECT
-directive @directive2 on INPUT_OBJECT | OBJECT
+directive @directive2 on INPUT_OBJECT | OBJECT | ENUM
 
 type TypeHonoringDirectiveReplacementsDefinitionType @directive1 @directive2 {
   field: String
@@ -9,10 +9,14 @@ input InputTypeThatShouldNotGetDirectiveReplacement @directive1 @directive2 {
   field: String
 }
 
-type MyDirectiveConsolidatedType @directive1 @directive2 {
+enum MyEnumWithDirectives @directive2 {
+  VALUE
+}
+
+type MyConsolidatedTypeWithDirectives @directive1 @directive2 {
   field: String
 }
 
-input MyDirectiveConsolidatedTypeInput @directive1 @directive2 {
+input MyConsolidatedTypeWithDirectivesInput @directive1 @directive2 {
   field: String
 }

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/schema.graphql
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/schema.graphql
@@ -1,5 +1,5 @@
 directive @directive1 on INPUT_OBJECT | OBJECT
-directive @directive2 on INPUT_OBJECT | OBJECT | ENUM
+directive @directive2 on INPUT_OBJECT | OBJECT
 
 type TypeHonoringDirectiveReplacementsDefinitionType @directive1 @directive2 {
   field: String
@@ -9,14 +9,18 @@ input InputTypeThatShouldNotGetDirectiveReplacement @directive1 @directive2 {
   field: String
 }
 
-enum MyEnumWithDirectives @directive2 {
-  VALUE
-}
-
-type MyConsolidatedTypeWithDirectives @directive1 @directive2 {
+type MyConsolidatedTypeWithDirectives @directive1 {
   field: String
 }
 
-input MyConsolidatedTypeWithDirectivesInput @directive1 @directive2 {
+input MyConsolidatedTypeWithDirectivesInput @directive1 {
+  field: String
+}
+
+type MyConsolidatedTypeWithDirectives2 @directive2 {
+  field: String
+}
+
+input MyConsolidatedTypeWithDirectives2Input @directive2 {
   field: String
 }

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/schema.graphql
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/schema.graphql
@@ -1,7 +1,7 @@
 directive @directive1 on INPUT_OBJECT | OBJECT
 directive @directive2 on INPUT_OBJECT | OBJECT
 
-type TypeHonoringDirectiveReplacementsDefinitionType @directive1 @directive2 {
+type TypeThatShouldGetDirectiveReplacement @directive1 @directive2 {
   field: String
 }
 

--- a/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/schema.graphql
+++ b/test/unit/should_ignore_filtered_directiveReplacements_for_consolidated_types/schema.graphql
@@ -1,0 +1,18 @@
+directive @directive1 on INPUT_OBJECT | OBJECT
+directive @directive2 on INPUT_OBJECT | OBJECT
+
+type TypeHonoringDirectiveReplacementsDefinitionType @directive1 @directive2 {
+  field: String
+}
+
+input InputTypeThatShouldNotGetDirectiveReplacement @directive1 @directive2 {
+  field: String
+}
+
+type MyDirectiveConsolidatedType @directive1 @directive2 {
+  field: String
+}
+
+input MyDirectiveConsolidatedTypeInput @directive1 @directive2 {
+  field: String
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Fixes an issue where directive replacements could happen on consolidated classes even when the configuration limits the replacement to happen only on output or input definition types.

