### PR TITLE
fix: preserve case in directive name

### DIFF
--- a/src/definitions/directive.ts
+++ b/src/definitions/directive.ts
@@ -25,7 +25,7 @@ export function buildDirectiveDefinition(
     return "";
   }
   return `@GraphQLDirective(
-    name = "${titleCase(directiveName)}",
+    name = "${directiveName}",
     description = "${node.description?.value ?? ""}",
     locations = [${node.locations.map((location) => `graphql.introspection.Introspection.DirectiveLocation.${location.value}`).join(", ")}]
 )

--- a/test/unit/should_generate_custom_directives/expected.kt
+++ b/test/unit/should_generate_custom_directives/expected.kt
@@ -4,14 +4,14 @@ import com.expediagroup.graphql.generator.annotations.*
 import should_honor_directiveReplacements_config.*
 
 @GraphQLDirective(
-    name = "MyCustomDirective",
-    description = "A description for MyCustomDirective",
+    name = "myCustomDirective",
+    description = "A description for myCustomDirective",
     locations = [graphql.introspection.Introspection.DirectiveLocation.OBJECT, graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION, graphql.introspection.Introspection.DirectiveLocation.INPUT_OBJECT, graphql.introspection.Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION]
 )
 annotation class MyCustomDirective
 
 @GraphQLDirective(
-    name = "MyCustomDirective2",
+    name = "myCustomDirective2",
     description = "",
     locations = [graphql.introspection.Introspection.DirectiveLocation.OBJECT, graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION, graphql.introspection.Introspection.DirectiveLocation.INPUT_OBJECT, graphql.introspection.Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION]
 )

--- a/test/unit/should_generate_custom_directives/schema.graphql
+++ b/test/unit/should_generate_custom_directives/schema.graphql
@@ -1,4 +1,4 @@
-"A description for MyCustomDirective"
+"A description for myCustomDirective"
 directive @myCustomDirective on OBJECT | FIELD_DEFINITION | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @myCustomDirective2 on OBJECT | FIELD_DEFINITION | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- GraphQL Kotlin will generate directives based on the case passed to the `name` argument
