### PR TITLE
Add fields field which defines scope of classMethods value

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -161,6 +161,7 @@ export const configSchema = object({
     array(
       object({
         typeName: string(),
+        fields: optional(array(string())),
         classMethods: optional(
           union([literal("SUSPEND"), literal("COMPLETABLE_FUTURE")]),
         ),

--- a/src/definitions/field.ts
+++ b/src/definitions/field.ts
@@ -27,6 +27,16 @@ import { findTypeInResolverInterfacesConfig } from "../config/find-type-in-resol
 import { shouldGenerateFunctionsInClass } from "./object";
 import { sanitizeName } from "../utils/sanitize-name";
 
+function computeIsFieldInScope(
+  typeInResolverInterfacesConfig: ReturnType<
+    typeof findTypeInResolverInterfacesConfig
+  >,
+  fieldNode: FieldDefinitionNode,
+): boolean {
+  const configFields = typeInResolverInterfacesConfig?.fields;
+  return !configFields?.length || configFields.includes(fieldNode.name.value);
+}
+
 export function buildObjectFieldDefinition({
   node,
   fieldNode,
@@ -50,11 +60,16 @@ export function buildObjectFieldDefinition({
     config,
   );
   const typeMetadata = buildTypeMetadata(fieldNode.type, schema, config);
+  const isFieldInScope = computeIsFieldInScope(
+    typeInResolverInterfacesConfig,
+    fieldNode,
+  );
   const defaultImplementation = getDefaultImplementation(
     node,
     fieldNode,
     typeInResolverInterfacesConfig,
     typeMetadata,
+    isFieldInScope,
   );
   const defaultFunctionValue = `${typeMetadata.isNullable ? "?" : ""} = ${defaultImplementation}`;
   const shouldGenerateFunctions = shouldGenerateFunctionsInClass(
@@ -71,6 +86,7 @@ export function buildObjectFieldDefinition({
     defaultValue,
     typeInResolverInterfacesConfig,
     typeMetadata,
+    isFieldInScope,
   );
   const annotations = buildAnnotations({
     schema,
@@ -105,6 +121,10 @@ export function buildConstructorFieldDefinition({
   );
   const typeMetadata = buildTypeMetadata(fieldNode.type, schema, config);
   const defaultDefinitionValue = typeMetadata.defaultValue;
+  const isFieldInScope = computeIsFieldInScope(
+    typeInResolverInterfacesConfig,
+    fieldNode,
+  );
 
   const field = buildField(
     node,
@@ -113,6 +133,7 @@ export function buildConstructorFieldDefinition({
     defaultDefinitionValue,
     typeInResolverInterfacesConfig,
     typeMetadata,
+    isFieldInScope,
   );
   const annotations = buildAnnotations({
     schema,
@@ -152,6 +173,10 @@ export function buildInterfaceFieldDefinition({
   );
   const typeMetadata = buildTypeMetadata(fieldNode.type, schema, config);
   const defaultDefinitionValue = typeMetadata.isNullable ? "?" : "";
+  const isFieldInScope = computeIsFieldInScope(
+    typeInResolverInterfacesConfig,
+    fieldNode,
+  );
   const field = buildField(
     node,
     fieldNode,
@@ -159,6 +184,7 @@ export function buildInterfaceFieldDefinition({
     defaultDefinitionValue,
     typeInResolverInterfacesConfig,
     typeMetadata,
+    isFieldInScope,
   );
   const annotations = buildAnnotations({
     schema,
@@ -178,16 +204,15 @@ function buildField(
     typeof findTypeInResolverInterfacesConfig
   >,
   typeMetadata: TypeMetadata,
+  isFieldInScope: boolean,
 ) {
   const defaultImplementation = getDefaultImplementation(
     node,
     fieldNode,
     typeInResolverInterfacesConfig,
     typeMetadata,
+    isFieldInScope,
   );
-  const configFields = typeInResolverInterfacesConfig?.fields;
-  const isFieldInScope =
-    !configFields?.length || configFields.includes(fieldNode.name.value);
   const isCompletableFuture =
     typeInResolverInterfacesConfig?.classMethods === "COMPLETABLE_FUTURE" &&
     isFieldInScope;
@@ -267,9 +292,10 @@ function buildFieldModifier(
   if (!typeInResolverInterfacesConfig && !fieldNode.arguments?.length) {
     return shouldOverrideField ? "override val" : "val";
   }
-  const configFields = typeInResolverInterfacesConfig?.fields;
-  const isFieldInScope =
-    !configFields?.length || configFields.includes(fieldNode.name.value);
+  const isFieldInScope = computeIsFieldInScope(
+    typeInResolverInterfacesConfig,
+    fieldNode,
+  );
   const functionModifier =
     typeInResolverInterfacesConfig?.classMethods === "SUSPEND" && isFieldInScope
       ? "suspend "
@@ -339,6 +365,7 @@ function getDefaultImplementation(
     typeof findTypeInResolverInterfacesConfig
   >,
   typeMetadata: TypeMetadata,
+  isFieldInScope: boolean,
 ) {
   const notImplementedError = `throw NotImplementedError("${node.name.value}.${fieldNode.name.value} must be implemented.")`;
 
@@ -351,10 +378,6 @@ function getDefaultImplementation(
     }
     return notImplementedError;
   }
-
-  const configFields = typeInResolverInterfacesConfig?.fields;
-  const isFieldInScope =
-    !configFields?.length || configFields.includes(fieldNode.name.value);
 
   if (typeMetadata.isNullable) {
     return getNullableFieldDefaultValue(

--- a/src/definitions/field.ts
+++ b/src/definitions/field.ts
@@ -263,15 +263,19 @@ function buildFieldModifier(
   if (!typeInResolverInterfacesConfig && !fieldNode.arguments?.length) {
     return shouldOverrideField ? "override val" : "val";
   }
+  const configFields = typeInResolverInterfacesConfig?.fields;
+  const isFieldInScope =
+    !configFields?.length || configFields.includes(fieldNode.name.value);
   const functionModifier =
-    typeInResolverInterfacesConfig?.classMethods === "SUSPEND"
+    typeInResolverInterfacesConfig?.classMethods === "SUSPEND" && isFieldInScope
       ? "suspend "
       : "";
   if (node.kind === Kind.INTERFACE_TYPE_DEFINITION) {
     return `${functionModifier}fun`;
   }
   const isCompletableFuture =
-    typeInResolverInterfacesConfig?.classMethods === "COMPLETABLE_FUTURE";
+    typeInResolverInterfacesConfig?.classMethods === "COMPLETABLE_FUTURE" &&
+    isFieldInScope;
   if (shouldOverrideField && !isCompletableFuture) {
     return "override fun";
   }

--- a/src/definitions/field.ts
+++ b/src/definitions/field.ts
@@ -185,8 +185,12 @@ function buildField(
     typeInResolverInterfacesConfig,
     typeMetadata,
   );
+  const configFields = typeInResolverInterfacesConfig?.fields;
+  const isFieldInScope =
+    !configFields?.length || configFields.includes(fieldNode.name.value);
   const isCompletableFuture =
-    typeInResolverInterfacesConfig?.classMethods === "COMPLETABLE_FUTURE";
+    typeInResolverInterfacesConfig?.classMethods === "COMPLETABLE_FUTURE" &&
+    isFieldInScope;
   const isDataFetcherResult = typeInResolverInterfacesConfig?.dataFetcherResult;
   let typeDefinition = `${typeMetadata.typeName}${typeMetadata.isNullable ? "?" : ""}`;
   let defaultDefinition = `${typeMetadata.typeName}${defaultDefinitionValue}`;

--- a/src/definitions/field.ts
+++ b/src/definitions/field.ts
@@ -352,10 +352,15 @@ function getDefaultImplementation(
     return notImplementedError;
   }
 
+  const configFields = typeInResolverInterfacesConfig?.fields;
+  const isFieldInScope =
+    !configFields?.length || configFields.includes(fieldNode.name.value);
+
   if (typeMetadata.isNullable) {
     return getNullableFieldDefaultValue(
       typeInResolverInterfacesConfig,
       typeMetadata,
+      isFieldInScope,
     );
   }
   return notImplementedError;
@@ -366,9 +371,11 @@ function getNullableFieldDefaultValue(
     ReturnType<typeof findTypeInResolverInterfacesConfig>
   >,
   typeMetadata: TypeMetadata,
+  isFieldInScope: boolean,
 ) {
   const isCompletableFuture =
-    typeInResolverInterfacesConfig.classMethods === "COMPLETABLE_FUTURE";
+    typeInResolverInterfacesConfig.classMethods === "COMPLETABLE_FUTURE" &&
+    isFieldInScope;
   const isDataFetcherResult = typeInResolverInterfacesConfig.dataFetcherResult;
 
   if (isCompletableFuture && isDataFetcherResult) {

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/codegen.config.ts
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/codegen.config.ts
@@ -1,0 +1,11 @@
+import { GraphQLKotlinCodegenConfig } from "../../../src/plugin";
+
+export default {
+  resolverInterfaces: [
+    {
+      typeName: "MyCompletableFutureFieldsType",
+      classMethods: "COMPLETABLE_FUTURE",
+      fields: ["completableFutureField"],
+    },
+  ],
+} satisfies GraphQLKotlinCodegenConfig;

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
@@ -6,4 +6,5 @@ import com.expediagroup.graphql.generator.annotations.*
 open class MyCompletableFutureFieldsType {
     open fun completableFutureField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?> = java.util.concurrent.CompletableFuture.completedFuture(null)
     open fun normalField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("MyCompletableFutureFieldsType.normalField must be implemented.")
+    open fun outOfScopeNullableField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
 }

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
@@ -5,5 +5,5 @@ import com.expediagroup.graphql.generator.annotations.*
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
 open class MyCompletableFutureFieldsType {
     open fun completableFutureField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?> = java.util.concurrent.CompletableFuture.completedFuture(null)
-    open fun normalField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String> = throw NotImplementedError("MyCompletableFutureFieldsType.normalField must be implemented.")
+    open fun normalField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("MyCompletableFutureFieldsType.normalField must be implemented.")
 }

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
@@ -1,0 +1,9 @@
+package com.kotlin.generated
+
+import com.expediagroup.graphql.generator.annotations.*
+
+@GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
+open class MyCompletableFutureFieldsType {
+    open fun completableFutureField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?> = java.util.concurrent.CompletableFuture.completedFuture(null)
+    open fun normalField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String> = throw NotImplementedError("MyCompletableFutureFieldsType.normalField must be implemented.")
+}

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/schema.graphql
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/schema.graphql
@@ -1,0 +1,4 @@
+type MyCompletableFutureFieldsType {
+  completableFutureField: String
+  normalField: String!
+}

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/schema.graphql
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/schema.graphql
@@ -1,4 +1,5 @@
 type MyCompletableFutureFieldsType {
   completableFutureField: String
   normalField: String!
+  outOfScopeNullableField: String
 }

--- a/test/unit/should_honor_classMethods_suspend_with_fields/codegen.config.ts
+++ b/test/unit/should_honor_classMethods_suspend_with_fields/codegen.config.ts
@@ -1,0 +1,11 @@
+import { GraphQLKotlinCodegenConfig } from "../../../src/plugin";
+
+export default {
+  resolverInterfaces: [
+    {
+      typeName: "MySuspendFieldsType",
+      classMethods: "SUSPEND",
+      fields: ["suspendField"],
+    },
+  ],
+} satisfies GraphQLKotlinCodegenConfig;

--- a/test/unit/should_honor_classMethods_suspend_with_fields/expected.kt
+++ b/test/unit/should_honor_classMethods_suspend_with_fields/expected.kt
@@ -1,0 +1,9 @@
+package com.kotlin.generated
+
+import com.expediagroup.graphql.generator.annotations.*
+
+@GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
+open class MySuspendFieldsType {
+    open suspend fun suspendField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
+    open fun normalField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("MySuspendFieldsType.normalField must be implemented.")
+}

--- a/test/unit/should_honor_classMethods_suspend_with_fields/schema.graphql
+++ b/test/unit/should_honor_classMethods_suspend_with_fields/schema.graphql
@@ -1,0 +1,4 @@
+type MySuspendFieldsType {
+  suspendField: String
+  normalField: String!
+}


### PR DESCRIPTION
When `fields` is defined, the value of `classMethods` will only apply to fields in that list. If it isn't defined, the value of `classMethods` will apply to all fields on the specified type