### PR TITLE
feat: add fields field to filter what resolverInterfaces.classMethods applies to

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -161,6 +161,7 @@ export const configSchema = object({
     array(
       object({
         typeName: string(),
+        fields: optional(array(string())),
         classMethods: optional(
           union([literal("SUSPEND"), literal("COMPLETABLE_FUTURE")]),
         ),

--- a/src/definitions/field.ts
+++ b/src/definitions/field.ts
@@ -87,16 +87,22 @@ export function buildConstructorFieldDefinition({
   fieldNode,
   schema,
   config,
+  typeInResolverInterfacesConfigOverride,
 }: {
   node: ObjectTypeDefinitionNode;
   fieldNode: FieldDefinitionNode;
   schema: GraphQLSchema;
   config: CodegenConfigWithDefaults;
+  typeInResolverInterfacesConfigOverride?: ReturnType<
+    typeof findTypeInResolverInterfacesConfig
+  > | null;
 }) {
-  const typeInResolverInterfacesConfig = findTypeInResolverInterfacesConfig(
-    node,
-    config,
-  );
+  const typeInResolverInterfacesConfig: ReturnType<
+    typeof findTypeInResolverInterfacesConfig
+  > =
+    typeInResolverInterfacesConfigOverride === undefined
+      ? findTypeInResolverInterfacesConfig(node, config)
+      : (typeInResolverInterfacesConfigOverride ?? undefined);
   const functionDefinition = buildConstructorFunctionDefinition(
     node,
     fieldNode,

--- a/src/definitions/object.ts
+++ b/src/definitions/object.ts
@@ -104,47 +104,12 @@ ${getClassMembers({ node, fieldNodes, schema, config })}
     typeInResolverInterfacesConfig,
   );
   if (shouldGenerateFunctions) {
-    let constructor = "";
-    if (resolverFields) {
-      const nonResolverFields = node.fields?.filter(
-        (f) => !resolverFields.includes(f.name.value),
-      );
-      if (nonResolverFields?.length) {
-        const configWithoutResolver = {
-          ...config,
-          resolverInterfaces: config.resolverInterfaces.filter(
-            (r) => r.typeName !== node.name.value,
-          ),
-        } as typeof config;
-        constructor = `(\n${nonResolverFields
-          .map((fieldNode) =>
-            buildConstructorFieldDefinition({
-              node,
-              fieldNode,
-              schema,
-              config: configWithoutResolver,
-            }).replace(/,$/, ""),
-          )
-          .join(",\n")}\n)`;
-      }
-    } else {
-      const atLeastOneFieldHasNoArguments = node.fields?.some(
-        (fieldNode) => !fieldNode.arguments?.length,
-      );
-      if (!typeInResolverInterfacesConfig && atLeastOneFieldHasNoArguments) {
-        constructor = `(\n${node.fields
-          ?.map((fieldNode) => {
-            return buildConstructorFieldDefinition({
-              node,
-              fieldNode,
-              schema,
-              config,
-            });
-          })
-          .join(",\n")}\n)`;
-      }
-    }
-
+    const constructor = buildConstructor(
+      node,
+      typeInResolverInterfacesConfig,
+      schema,
+      config,
+    );
     return `${annotations}${outputRestrictionAnnotation}open class ${name}${constructor}${interfaceInheritance} {
 ${getClassMembers({ node, fieldNodes, schema, config })}
 }`;
@@ -153,6 +118,55 @@ ${getClassMembers({ node, fieldNodes, schema, config })}
   return `${annotations}${outputRestrictionAnnotation}data class ${name}(
 ${getClassMembers({ node, schema, config })}
 )${interfaceInheritance}`;
+}
+
+function buildConstructor(
+  node: ObjectTypeDefinitionNode,
+  typeInResolverInterfacesConfig: ReturnType<
+    typeof findTypeInResolverInterfacesConfig
+  >,
+  schema: GraphQLSchema,
+  config: CodegenConfigWithDefaults,
+): string {
+  const resolverFields = typeInResolverInterfacesConfig?.fields;
+
+  if (resolverFields) {
+    const nonResolverFields = node.fields?.filter(
+      (f) => !resolverFields.includes(f.name.value),
+    );
+    if (!nonResolverFields?.length) return "";
+    const configWithoutResolver = {
+      ...config,
+      resolverInterfaces: config.resolverInterfaces.filter(
+        (r) => r.typeName !== node.name.value,
+      ),
+    } as typeof config;
+    return `(\n${nonResolverFields
+      .map((fieldNode) =>
+        buildConstructorFieldDefinition({
+          node,
+          fieldNode,
+          schema,
+          config: configWithoutResolver,
+        }).replace(/,$/, ""),
+      )
+      .join(",\n")}\n)`;
+  }
+
+  if (typeInResolverInterfacesConfig) return "";
+
+  const fieldsForConstructor = node.fields?.filter((f) => !f.arguments?.length);
+  if (!fieldsForConstructor?.length) return "";
+  return `(\n${node.fields
+    ?.map((fieldNode) =>
+      buildConstructorFieldDefinition({
+        node,
+        fieldNode,
+        schema,
+        config,
+      }),
+    )
+    .join(",\n")}\n)`;
 }
 
 function getClassMembers({

--- a/src/definitions/object.ts
+++ b/src/definitions/object.ts
@@ -72,11 +72,14 @@ export function buildObjectTypeDefinition(
     node,
     config,
   );
+  const resolverFields = typeInResolverInterfacesConfig?.fields;
   const fieldsWithArguments = node.fields?.filter(
     (fieldNode) => fieldNode.arguments?.length,
   );
   const fieldNodes = typeInResolverInterfacesConfig
-    ? node.fields
+    ? resolverFields
+      ? node.fields?.filter((f) => resolverFields.includes(f.name.value))
+      : node.fields
     : fieldsWithArguments;
 
   const isTopLevelType =
@@ -101,22 +104,46 @@ ${getClassMembers({ node, fieldNodes, schema, config })}
     typeInResolverInterfacesConfig,
   );
   if (shouldGenerateFunctions) {
-    const atLeastOneFieldHasNoArguments = node.fields?.some(
-      (fieldNode) => !fieldNode.arguments?.length,
-    );
-    const constructor =
-      !typeInResolverInterfacesConfig && atLeastOneFieldHasNoArguments
-        ? `(\n${node.fields
-            ?.map((fieldNode) => {
-              return buildConstructorFieldDefinition({
-                node,
-                fieldNode,
-                schema,
-                config,
-              });
-            })
-            .join(",\n")}\n)`
-        : "";
+    let constructor = "";
+    if (resolverFields) {
+      const nonResolverFields = node.fields?.filter(
+        (f) => !resolverFields.includes(f.name.value),
+      );
+      if (nonResolverFields?.length) {
+        const configWithoutResolver = {
+          ...config,
+          resolverInterfaces: config.resolverInterfaces.filter(
+            (r) => r.typeName !== node.name.value,
+          ),
+        } as typeof config;
+        constructor = `(\n${nonResolverFields
+          .map((fieldNode) =>
+            buildConstructorFieldDefinition({
+              node,
+              fieldNode,
+              schema,
+              config: configWithoutResolver,
+            }),
+          )
+          .join("\n")}\n)`;
+      }
+    } else {
+      const atLeastOneFieldHasNoArguments = node.fields?.some(
+        (fieldNode) => !fieldNode.arguments?.length,
+      );
+      if (!typeInResolverInterfacesConfig && atLeastOneFieldHasNoArguments) {
+        constructor = `(\n${node.fields
+          ?.map((fieldNode) => {
+            return buildConstructorFieldDefinition({
+              node,
+              fieldNode,
+              schema,
+              config,
+            });
+          })
+          .join(",\n")}\n)`;
+      }
+    }
 
     return `${annotations}${outputRestrictionAnnotation}open class ${name}${constructor}${interfaceInheritance} {
 ${getClassMembers({ node, fieldNodes, schema, config })}

--- a/src/definitions/object.ts
+++ b/src/definitions/object.ts
@@ -76,11 +76,11 @@ export function buildObjectTypeDefinition(
   const fieldsWithArguments = node.fields?.filter(
     (fieldNode) => fieldNode.arguments?.length,
   );
-  const fieldNodes = typeInResolverInterfacesConfig
-    ? resolverFields
+  const fieldNodes = !typeInResolverInterfacesConfig
+    ? fieldsWithArguments
+    : resolverFields
       ? node.fields?.filter((f) => resolverFields.includes(f.name.value))
-      : node.fields
-    : fieldsWithArguments;
+      : node.fields;
 
   const isTopLevelType =
     node.name.value === "Query" || node.name.value === "Mutation";

--- a/src/definitions/object.ts
+++ b/src/definitions/object.ts
@@ -123,9 +123,9 @@ ${getClassMembers({ node, fieldNodes, schema, config })}
               fieldNode,
               schema,
               config: configWithoutResolver,
-            }),
+            }).replace(/,$/, ""),
           )
-          .join("\n")}\n)`;
+          .join(",\n")}\n)`;
       }
     } else {
       const atLeastOneFieldHasNoArguments = node.fields?.some(

--- a/src/definitions/object.ts
+++ b/src/definitions/object.ts
@@ -135,19 +135,14 @@ function buildConstructor(
       (f) => !resolverFields.includes(f.name.value),
     );
     if (!nonResolverFields?.length) return "";
-    const configWithoutResolver = {
-      ...config,
-      resolverInterfaces: config.resolverInterfaces.filter(
-        (r) => r.typeName !== node.name.value,
-      ),
-    } as typeof config;
     return `(\n${nonResolverFields
       .map((fieldNode) =>
         buildConstructorFieldDefinition({
           node,
           fieldNode,
           schema,
-          config: configWithoutResolver,
+          config,
+          typeInResolverInterfacesConfigOverride: null,
         }).replace(/,$/, ""),
       )
       .join(",\n")}\n)`;

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/codegen.config.ts
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/codegen.config.ts
@@ -1,0 +1,11 @@
+import { GraphQLKotlinCodegenConfig } from "../../../src/plugin";
+
+export default {
+  resolverInterfaces: [
+    {
+      typeName: "MyCompletableFutureFieldsType",
+      classMethods: "COMPLETABLE_FUTURE",
+      fields: ["completableFutureField", "nullableCompletableFutureField"],
+    },
+  ],
+} satisfies GraphQLKotlinCodegenConfig;

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
@@ -1,0 +1,12 @@
+package com.kotlin.generated
+
+import com.expediagroup.graphql.generator.annotations.*
+
+@GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
+open class MyCompletableFutureFieldsType(
+    val normalField: String,
+    val normalNullableField: String? = null,
+) {
+    open fun completableFutureField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String> = throw NotImplementedError("MyCompletableFutureFieldsType.completableFutureField must be implemented.")
+    open fun nullableCompletableFutureField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?> = java.util.concurrent.CompletableFuture.completedFuture(null)
+}

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/expected.kt
@@ -5,7 +5,7 @@ import com.expediagroup.graphql.generator.annotations.*
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
 open class MyCompletableFutureFieldsType(
     val normalField: String,
-    val normalNullableField: String? = null,
+    val normalNullableField: String? = null
 ) {
     open fun completableFutureField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String> = throw NotImplementedError("MyCompletableFutureFieldsType.completableFutureField must be implemented.")
     open fun nullableCompletableFutureField(dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): java.util.concurrent.CompletableFuture<String?> = java.util.concurrent.CompletableFuture.completedFuture(null)

--- a/test/unit/should_honor_classMethods_completable_future_with_fields/schema.graphql
+++ b/test/unit/should_honor_classMethods_completable_future_with_fields/schema.graphql
@@ -1,0 +1,6 @@
+type MyCompletableFutureFieldsType {
+  completableFutureField: String!
+  normalField: String!
+  normalNullableField: String
+  nullableCompletableFutureField: String
+}

--- a/test/unit/should_honor_classMethods_suspend_with_fields/codegen.config.ts
+++ b/test/unit/should_honor_classMethods_suspend_with_fields/codegen.config.ts
@@ -1,0 +1,11 @@
+import { GraphQLKotlinCodegenConfig } from "../../../src/plugin";
+
+export default {
+  resolverInterfaces: [
+    {
+      typeName: "MySuspendFieldsType",
+      classMethods: "SUSPEND",
+      fields: ["suspendField", "nullableSuspendField"],
+    },
+  ],
+} satisfies GraphQLKotlinCodegenConfig;

--- a/test/unit/should_honor_classMethods_suspend_with_fields/expected.kt
+++ b/test/unit/should_honor_classMethods_suspend_with_fields/expected.kt
@@ -4,7 +4,7 @@ import com.expediagroup.graphql.generator.annotations.*
 
 @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
 open class MySuspendFieldsType(
-    val normalField: String
+    val normalField: String,
     val nullableNormalField: String? = null
 ) {
     open suspend fun suspendField(input: String? = null, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("MySuspendFieldsType.suspendField must be implemented.")

--- a/test/unit/should_honor_classMethods_suspend_with_fields/expected.kt
+++ b/test/unit/should_honor_classMethods_suspend_with_fields/expected.kt
@@ -1,0 +1,12 @@
+package com.kotlin.generated
+
+import com.expediagroup.graphql.generator.annotations.*
+
+@GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
+open class MySuspendFieldsType(
+    val normalField: String
+    val nullableNormalField: String? = null
+) {
+    open suspend fun suspendField(input: String? = null, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String = throw NotImplementedError("MySuspendFieldsType.suspendField must be implemented.")
+    open suspend fun nullableSuspendField(input: String? = null, dataFetchingEnvironment: graphql.schema.DataFetchingEnvironment): String? = null
+}

--- a/test/unit/should_honor_classMethods_suspend_with_fields/schema.graphql
+++ b/test/unit/should_honor_classMethods_suspend_with_fields/schema.graphql
@@ -1,0 +1,6 @@
+type MySuspendFieldsType {
+  suspendField(input: String): String!
+  nullableSuspendField(input: String): String
+  normalField: String!
+  nullableNormalField: String
+}


### PR DESCRIPTION
When `fields` is defined, the value of `classMethods` will only apply to fields in that list. If it isn't defined, the value of `classMethods` will apply to all fields on the specified type